### PR TITLE
Bumps TypeORM to 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Changed
+* `providers.TypeORMProvider`'s `entityManager` is now `readonly`
+* TypeORM dependency has been updated to `0.1.1` release
+
 ## [0.5.1] - 2017-10-06
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "mysql": "^2.14.1",
     "reflect-metadata": "^0.1.10",
     "rxjs": "^5.4.3",
-    "typeorm": "0.0.11",
+    "typeorm": "^0.1.1",
     "uuid": "^3.1.0"
   }
 }

--- a/src/providers/typeorm.ts
+++ b/src/providers/typeorm.ts
@@ -8,7 +8,7 @@ import { Config, HealthManager, Logger } from '../';
 @injectable()
 export class TypeORMProvider {
   public connection: Connection;
-  public entityManager: EntityManager;
+  public readonly entityManager: EntityManager;
   public health = new BehaviorSubject(false);
 
   public defaultConnectionOptions = {
@@ -36,8 +36,8 @@ export class TypeORMProvider {
     options.driver.username = this.config['dbUser'];
     options.driver.password = this.config['dbPassword'] || '';
     options.driver.database = this.config['dbName'];
-    options.driver.host     = this.config['dbHost'];
-    options.driver.port     = this.config['dbPort'];
+    options.driver.host = this.config['dbHost'];
+    options.driver.port = this.config['dbPort'];
 
     // We dont support autoschema sync, because we want to have auto retrying connection
     // we need to use connectionManager.create which doesn't support auto schema sync
@@ -47,7 +47,7 @@ export class TypeORMProvider {
 
     const connectionManager = getConnectionManager();
     this.connection = connectionManager.create(options);
-    this.entityManager = this.connection.entityManager;
+    this.entityManager = this.connection.manager;
     this.connect();
   }
 
@@ -69,7 +69,7 @@ export class TypeORMProvider {
   // Monitors database connection and will update the health accordingly
   private monitorHealth() {
     setInterval(() => {
-      this.entityManager.query('SELECT 1;')
+      this.connection.manager.query('SELECT 1;')
         .then(() => {
           this.health.next(true);
         })


### PR DESCRIPTION
This also introduces `readonly` access modifier on `entityManager`
property of `TypeORMProvider` and gives a clear-er way of deprecating
the property altogether in the future.

Closes #17