### PR TITLE
Fixes inheritance model for DbProvider

### DIFF
--- a/src/providers/db/mariadbProvider.ts
+++ b/src/providers/db/mariadbProvider.ts
@@ -23,7 +23,7 @@ export class MariadbProvider extends DbProvider implements EntityProvider {
     protected healthManager: HealthManager,
     protected logger: Logger,
   ) {
-    super();
+    super(healthManager);
 
     const providedOptions: Partial<MysqlConnectionOptions> = {
       username: (this.config as any)['dbUser'],

--- a/src/providers/typeorm.ts
+++ b/src/providers/typeorm.ts
@@ -14,12 +14,11 @@ export abstract class DbProvider {
   protected abstract logger: Logger;
   protected abstract config: Config;
   protected abstract connectionOptions: ConnectionOptions;
-  protected healthManager: HealthManager;
 
   protected reconnectTime = 3000;
   protected checkInterval = 5000;
 
-  constructor() {
+  constructor(protected healthManager: HealthManager) {
     this.health = new BehaviorSubject(false);
     this.healthManager.registerCheck('DB connection', this.health);
   }


### PR DESCRIPTION
Since parent's class constructor is called before properties of the child class are set access to `healthManager` would fail. This fixes this issue.