### PR TITLE
Add get method to the config object 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 * Fixes gRPC error code handling
 
+### Changed
+
+* Add an get method to the config object
+
 ## [0.6.3] - 2018-01-03
 
 ### Added

--- a/src/config.ts
+++ b/src/config.ts
@@ -126,4 +126,8 @@ export class Config {
       }
     };
   }
+
+  get(key: string): any  {
+    return (<any>this)[key];
+  }
 }

--- a/src/grpc-server.ts
+++ b/src/grpc-server.ts
@@ -127,9 +127,9 @@ export class GrpcServer {
 
     this.server = new grpc.Server();
     this.server.addService(this.service, this.services);
-    this.server.bind(`0.0.0.0:${(<any>this.config)['grpcPort']}`, grpc.ServerCredentials.createInsecure());
+    this.server.bind(`0.0.0.0:${this.config.get('grpcPort')}`, grpc.ServerCredentials.createInsecure());
     this.server.start();
-    this.logger.info(`Grpc server started listening on: ${(<any>this.config)['grpcPort']}`);
+    this.logger.info(`Grpc server started listening on: ${this.config.get('grpcPort')}`);
 
     // Notify the server is healhty
     this.health.next(true);

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -65,7 +65,7 @@ export class HttpServer {
     }));
 
     // Register health check endpoint
-    const healthUrl = this.normalizeURL((<any>this.config)['healthCheckURL'] || '/check');
+    const healthUrl = this.normalizeURL(this.config.get('healthCheckURL') || '/check');
 
     this.server.get(healthUrl, (_: Request, response: Response) => {
       const report = healthManager.getReport();
@@ -104,7 +104,7 @@ export class HttpServer {
   // Starts the http server
   public start() {
     // Set a 30 seconds request timeout
-    const connectTimeout: number = (<any>this.config)['connectTimeout'] || 30000;
+    const connectTimeout: number = this.config.get('connectTimeout') || 30000;
     this.server.use(timeout(`${connectTimeout}ms`));
 
     // 404 middleware
@@ -126,8 +126,8 @@ export class HttpServer {
       });
     });
 
-    this.server.listen((<any>this.config)['httpPort'], () => {
-      this.logger.info(`Http server starting listening on: ${(<any>this.config)['httpPort']} `);
+    this.server.listen(this.config.get('httpPort'), () => {
+      this.logger.info(`Http server starting listening on: ${this.config.get('httpPort')} `);
       this.health.next(true);
     });
   }
@@ -204,8 +204,8 @@ export class HttpServer {
     }
 
     // Check for root in config and prepend to the url
-    if ((<any>this.config)['httpRoot']) {
-      let httpRoot = (<any>this.config)['httpRoot'];
+    if (this.config.get('httpRoot')) {
+      let httpRoot = this.config.get('httpRoot');
 
       // Should start with an slash
       if (httpRoot.charAt(0) !== '/') {

--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -61,7 +61,7 @@ export class Logger {
   private handlers: Array<LogHandler> = [];
 
   constructor(private config: Config) {
-    switch ((<any>this.config)['logLevel'] || LogLevel.DEBUG) {
+    switch (this.config.get('logLevel') || LogLevel.DEBUG) {
       case 'debug': this.logLevel = LogLevel.DEBUG; break;
       case 'info': this.logLevel = LogLevel.INFO; break;
       case 'warn': this.logLevel = LogLevel.WARN; break;
@@ -73,7 +73,7 @@ export class Logger {
       this._debug = true;
     }
 
-    const loggerOptions: LoggerOptions = (<any>this.config)['loggerOptions']
+    const loggerOptions: LoggerOptions = this.config.get('loggerOptions');
     const processors = loggerOptions && loggerOptions.processors ? loggerOptions.processors : this.defaultProcessors;
     const handlers = loggerOptions && loggerOptions.handlers ? loggerOptions.handlers : this.defaultHandlers;
 

--- a/src/providers/db/mariadbProvider.ts
+++ b/src/providers/db/mariadbProvider.ts
@@ -26,11 +26,11 @@ export class MariadbProvider extends DbProvider implements EntityProvider {
     super(healthManager);
 
     const providedOptions: Partial<MysqlConnectionOptions> = {
-      username: (this.config as any)['dbUser'],
-      password: (this.config as any)['dbPassword'] || '',
-      database: (this.config as any)['dbName'],
-      host: (this.config as any)['dbHost'],
-      port: (this.config as any)['dbPort'],
+      username: this.config.get('dbUser'),
+      password: this.config.get('dbPassword') || '',
+      database: this.config.get('dbName'),
+      host: this.config.get('dbHost'),
+      port: this.config.get('dbPort'),
       entities: this.entities
     };
     const options: ConnectionOptions = deepmerge(this.connectionOptions, providedOptions);

--- a/test/config.spec.ts
+++ b/test/config.spec.ts
@@ -13,11 +13,11 @@ describe('Config', () => {
   });
 
   it('It should have default ports for http and grpc', () => {
-    expect((<any>config)['httpPort']).to.equal(8000);
-    expect((<any>config)['grpcPort']).to.equal(9000);
+    expect(config.get('httpPort')).to.equal(8000);
+    expect(config.get('grpcPort')).to.equal(9000);
   });
 
   it('Default log level should be info', () => {
-    expect((<any>config)['logLevel']).to.equal('info');
+    expect(config.get('logLevel')).to.equal('info');
   });
 });

--- a/test/http-server.spec.ts
+++ b/test/http-server.spec.ts
@@ -256,7 +256,7 @@ describe('Http server', () => {
     it('It should call listen on express when starting server with the correct port', () => {
       httpServer.start();
       expect(listenSpy).to.have.been.calledOnce;
-      expect(listenSpy.getCall(0).args[0]).to.equal((<any>config)['httpPort']);
+      expect(listenSpy.getCall(0).args[0]).to.equal(config.get('httpPort'));
     });
 
     it('It should send out an health update when the server is started', () => {


### PR DESCRIPTION
Adds an get method to the config object to remove the need of type casting to any when using properties of the config object.